### PR TITLE
Add runtime config and run-case CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ dfode-kit CMD ARGS
 
 
 ### Commands Available:
+- `config`: Store machine-local runtime paths such as OpenFOAM, Conda, and DeepFlame activation scripts.
 - `init`: Initialize canonical cases from explicit presets.
+- `run-case`: Execute a case-local runner such as `Allrun` using stored runtime configuration.
 - `sample`: Perform raw data sampling from canonical flame simulations.
 - `augment`: Apply random noise and physical constraints to improve the training dataset.
 - `label`: Generate supervised learning labels using Cantera's CVODE solver.

--- a/README.md
+++ b/README.md
@@ -43,18 +43,40 @@ dfode-kit CMD ARGS
 - `label`: Generate supervised learning labels using Cantera's CVODE solver.
 - `train`: Train neural network models based on the specified datasets and parameters.
 
-For example, preview a parameterized 1D premixed flame case:
+For example, a validated end-to-end 1D flame workflow is:
 
 ```bash
-dfode-kit init oneD-flame \
-  --mech /path/to/gri30.yaml \
+# one-time machine-local runtime config
+dfode-kit config set openfoam_bashrc /opt/openfoam7/etc/bashrc
+dfode-kit config set conda_sh /home/xk/miniconda3/etc/profile.d/conda.sh
+dfode-kit config set conda_env_name deepflame
+dfode-kit config set deepflame_bashrc /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+
+# init case from a DeepFlame-compatible Python env
+source /opt/openfoam7/etc/bashrc
+source /home/xk/miniconda3/etc/profile.d/conda.sh
+conda activate deepflame
+source /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+python -m dfode_kit.cli_tools.main init oneD-flame \
+  --mech /home/xk/deepflame/df_1be82b6/deepflame-dev/mechanisms/CH4/gri30.yaml \
   --fuel CH4:1 \
   --oxidizer air \
   --phi 1.0 \
-  --out /tmp/ch4_phi1_case \
-  --preview --json
-```
+  --out /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --apply --force
 
+# run case
+python -m dfode_kit.cli_tools.main run-case \
+  --case /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --apply --json
+
+# sample case
+python -m dfode_kit.cli_tools.main sample \
+  --mech /home/xk/deepflame/df_1be82b6/deepflame-dev/mechanisms/CH4/gri30.yaml \
+  --case /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --save /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli/ch4_phi1_sample.h5 \
+  --include_mesh
+```
 
 Comprehensive tutorials are provided in the `tutorials/` directory, including step-by-step guides for 1D premixed flames and 2D HIT flames.
 

--- a/dfode_kit/cli_tools/command_loader.py
+++ b/dfode_kit/cli_tools/command_loader.py
@@ -15,9 +15,17 @@ _COMMAND_SPECS = {
         'module': 'dfode_kit.cli_tools.commands.init',
         'help': 'Initialize canonical cases from explicit presets.',
     },
+    'config': {
+        'module': 'dfode_kit.cli_tools.commands.config',
+        'help': 'Manage persistent runtime configuration.',
+    },
     'label': {
         'module': 'dfode_kit.cli_tools.commands.label',
         'help': 'Label data.',
+    },
+    'run-case': {
+        'module': 'dfode_kit.cli_tools.commands.run_case',
+        'help': 'Run a DeepFlame/OpenFOAM case using stored configuration.',
     },
     'sample': {
         'module': 'dfode_kit.cli_tools.commands.sample',

--- a/dfode_kit/cli_tools/commands/config.py
+++ b/dfode_kit/cli_tools/commands/config.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+
+def add_command_parser(subparsers):
+    config_parser = subparsers.add_parser(
+        'config',
+        help='Manage persistent DFODE-kit runtime configuration.',
+    )
+    config_subparsers = config_parser.add_subparsers(dest='config_command')
+
+    path_parser = config_subparsers.add_parser('path', help='Print the runtime config file path.')
+    path_parser.add_argument('--json', action='store_true', help='Print structured JSON output.')
+
+    show_parser = config_subparsers.add_parser('show', help='Show the current runtime configuration.')
+    show_parser.add_argument('--json', action='store_true', help='Print structured JSON output.')
+
+    schema_parser = config_subparsers.add_parser('schema', help='Show supported config keys and defaults.')
+    schema_parser.add_argument('--json', action='store_true', help='Print structured JSON output.')
+
+    set_parser = config_subparsers.add_parser('set', help='Persist a config key/value pair.')
+    set_parser.add_argument('key', type=str)
+    set_parser.add_argument('value', type=str)
+    set_parser.add_argument('--json', action='store_true', help='Print structured JSON output.')
+
+    unset_parser = config_subparsers.add_parser('unset', help='Reset a config key to its default.')
+    unset_parser.add_argument('key', type=str)
+    unset_parser.add_argument('--json', action='store_true', help='Print structured JSON output.')
+
+
+def handle_command(args):
+    from dfode_kit.runtime_config import (
+        describe_config_schema,
+        get_config_path,
+        load_runtime_config,
+        set_config_value,
+        unset_config_value,
+    )
+
+    if args.config_command == 'path':
+        path = str(get_config_path())
+        if args.json:
+            print(json.dumps({'config_path': path}, indent=2, sort_keys=True))
+        else:
+            print(path)
+        return
+
+    if args.config_command == 'show':
+        config = load_runtime_config()
+        if args.json:
+            print(json.dumps(config, indent=2, sort_keys=True))
+        else:
+            for key, value in config.items():
+                print(f'{key}: {value}')
+        return
+
+    if args.config_command == 'schema':
+        schema = describe_config_schema()
+        if args.json:
+            print(json.dumps(schema, indent=2, sort_keys=True))
+        else:
+            for key, meta in schema.items():
+                print(f'{key}:')
+                print(f'  description: {meta["description"]}')
+                print(f'  default: {meta["default"]}')
+        return
+
+    if args.config_command == 'set':
+        config, path = set_config_value(args.key, args.value)
+        if args.json:
+            print(json.dumps({'event': 'config_set', 'key': args.key, 'path': str(path), 'config': config}, indent=2, sort_keys=True))
+        else:
+            print(f'Set {args.key} in {path}')
+        return
+
+    if args.config_command == 'unset':
+        config, path = unset_config_value(args.key)
+        if args.json:
+            print(json.dumps({'event': 'config_unset', 'key': args.key, 'path': str(path), 'config': config}, indent=2, sort_keys=True))
+        else:
+            print(f'Unset {args.key} in {path}')
+        return
+
+    raise ValueError('The config command requires a subcommand: path, show, schema, set, or unset.')

--- a/dfode_kit/cli_tools/commands/run_case.py
+++ b/dfode_kit/cli_tools/commands/run_case.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def add_command_parser(subparsers):
+    run_case_parser = subparsers.add_parser(
+        'run-case',
+        help='Run a DeepFlame/OpenFOAM case using stored runtime configuration.',
+    )
+    run_case_parser.add_argument('--case', required=True, type=str, help='Path to the case directory.')
+    run_case_parser.add_argument(
+        '--runner',
+        default='Allrun',
+        type=str,
+        help='Case runner script to execute inside the case directory. Defaults to Allrun.',
+    )
+    run_case_parser.add_argument(
+        '--np',
+        type=int,
+        help='MPI rank count hint recorded in metadata. Defaults to config.default_np.',
+    )
+    run_case_parser.add_argument('--preview', action='store_true', help='Preview the resolved runtime command without executing it.')
+    run_case_parser.add_argument('--apply', action='store_true', help='Execute the case runner.')
+    run_case_parser.add_argument('--json', action='store_true', help='Print structured JSON output.')
+    run_case_parser.add_argument(
+        '--openfoam-bashrc',
+        type=str,
+        help='Override config.openfoam_bashrc for this invocation.',
+    )
+    run_case_parser.add_argument(
+        '--conda-sh',
+        type=str,
+        help='Override config.conda_sh for this invocation.',
+    )
+    run_case_parser.add_argument(
+        '--conda-env',
+        type=str,
+        help='Override config.conda_env_name for this invocation.',
+    )
+    run_case_parser.add_argument(
+        '--deepflame-bashrc',
+        type=str,
+        help='Override config.deepflame_bashrc for this invocation.',
+    )
+    run_case_parser.add_argument(
+        '--python-executable',
+        type=str,
+        help='Override config.python_executable for this invocation.',
+    )
+    run_case_parser.add_argument(
+        '--mpirun-command',
+        type=str,
+        help='Override config.mpirun_command for this invocation.',
+    )
+
+
+def handle_command(args):
+    from dfode_kit.cli_tools.commands.run_case_helpers import execute_run_case, resolve_run_case_plan
+
+    if not args.preview and not args.apply:
+        raise ValueError('Specify at least one action: --preview or --apply.')
+
+    plan = resolve_run_case_plan(args)
+    json_result = {'case_type': 'deepflame-run-case'} if args.json else None
+
+    if args.preview:
+        if args.json:
+            json_result['plan'] = plan
+        else:
+            _print_human_plan(plan)
+
+    if args.apply:
+        result = execute_run_case(plan, quiet=args.json)
+        if args.json:
+            json_result['apply'] = result
+        else:
+            print(f"Completed run-case in: {result['case_dir']}")
+            print(f"exit_code: {result['exit_code']}")
+            if result.get('stdout_log'):
+                print(f"stdout_log: {result['stdout_log']}")
+                print(f"stderr_log: {result['stderr_log']}")
+
+    if args.json:
+        print(json.dumps(json_result, indent=2, sort_keys=True))
+
+
+def _print_human_plan(plan: dict):
+    print('Resolved run-case plan')
+    print(f"case_dir: {plan['case_dir']}")
+    print(f"runner: {plan['runner']}")
+    print('runtime_config:')
+    for key, value in plan['runtime_config'].items():
+        print(f'  {key}: {value}')
+    print('shell_lines:')
+    for line in plan['shell_lines']:
+        print(f'  {line}')

--- a/dfode_kit/cli_tools/commands/run_case_helpers.py
+++ b/dfode_kit/cli_tools/commands/run_case_helpers.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from dfode_kit.runtime_config import resolve_runtime_config
+
+
+def resolve_run_case_plan(args) -> dict[str, Any]:
+    case_dir = Path(args.case).resolve()
+    if not case_dir.is_dir():
+        raise ValueError(f'Case directory does not exist: {case_dir}')
+
+    runner_path = case_dir / args.runner
+    if not runner_path.is_file():
+        raise ValueError(f'Case runner does not exist: {runner_path}')
+
+    runtime_config = resolve_runtime_config(
+        {
+            'openfoam_bashrc': args.openfoam_bashrc,
+            'conda_sh': args.conda_sh,
+            'conda_env_name': args.conda_env,
+            'deepflame_bashrc': args.deepflame_bashrc,
+            'python_executable': args.python_executable,
+            'mpirun_command': args.mpirun_command,
+            'default_np': args.np,
+        }
+    )
+    _validate_runtime_config(runtime_config)
+
+    shell_lines = [
+        f'source {shlex.quote(runtime_config["openfoam_bashrc"])}',
+        f'source {shlex.quote(runtime_config["conda_sh"])}',
+        f'conda activate {shlex.quote(runtime_config["conda_env_name"])}',
+        f'source {shlex.quote(runtime_config["deepflame_bashrc"])}',
+        'set -eo pipefail',
+        'which dfLowMachFoam',
+        f'cd {shlex.quote(str(case_dir))}',
+        f'chmod +x {shlex.quote(args.runner)}',
+        f'./{shlex.quote(args.runner)}',
+    ]
+
+    return {
+        'schema_version': 1,
+        'case_type': 'deepflame-run-case',
+        'case_dir': str(case_dir),
+        'runner': args.runner,
+        'np': runtime_config['default_np'],
+        'runtime_config': runtime_config,
+        'shell_lines': shell_lines,
+        'shell_script': '\n'.join(shell_lines),
+    }
+
+
+def execute_run_case(plan: dict[str, Any], quiet: bool = False) -> dict[str, Any]:
+    case_dir = Path(plan['case_dir']).resolve()
+    command = ['bash', '-lc', plan['shell_script']]
+
+    if quiet:
+        stdout_log = case_dir / 'log.dfode-run-case.stdout'
+        stderr_log = case_dir / 'log.dfode-run-case.stderr'
+        with stdout_log.open('w', encoding='utf-8') as stdout_handle, stderr_log.open('w', encoding='utf-8') as stderr_handle:
+            completed = subprocess.run(command, stdout=stdout_handle, stderr=stderr_handle, text=True)
+        result = {
+            'event': 'run_case_completed',
+            'case_dir': str(case_dir),
+            'runner': plan['runner'],
+            'exit_code': completed.returncode,
+            'stdout_log': str(stdout_log),
+            'stderr_log': str(stderr_log),
+        }
+    else:
+        completed = subprocess.run(command)
+        result = {
+            'event': 'run_case_completed',
+            'case_dir': str(case_dir),
+            'runner': plan['runner'],
+            'exit_code': completed.returncode,
+        }
+
+    if completed.returncode != 0:
+        raise ValueError(f"Case runner failed with exit code {completed.returncode}: {case_dir / plan['runner']}")
+
+    return result
+
+
+def _validate_runtime_config(config: dict[str, Any]):
+    required = ['openfoam_bashrc', 'conda_sh', 'conda_env_name', 'deepflame_bashrc']
+    missing = [key for key in required if not config.get(key)]
+    if missing:
+        raise ValueError(
+            'Missing runtime config values: '
+            + ', '.join(missing)
+            + '. Use `dfode-kit config set ...` or per-command overrides.'
+        )

--- a/dfode_kit/runtime_config.py
+++ b/dfode_kit/runtime_config.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+APP_NAME = "dfode-kit"
+CONFIG_FILENAME = "config.json"
+
+CONFIG_KEYS: dict[str, str] = {
+    "openfoam_bashrc": "Path to the OpenFOAM bashrc that should be sourced first.",
+    "conda_sh": "Path to conda.sh used to activate a Conda environment before sourcing DeepFlame.",
+    "conda_env_name": "Conda environment name used for Cantera/DeepFlame-compatible Python packages.",
+    "deepflame_bashrc": "Path to the DeepFlame bashrc sourced after OpenFOAM and Conda activation.",
+    "python_executable": "Optional Python executable path for future workflow commands and diagnostics.",
+    "default_np": "Default MPI rank count for case execution commands.",
+    "mpirun_command": "MPI launcher command used by case execution workflows.",
+}
+
+DEFAULT_CONFIG: dict[str, Any] = {
+    "openfoam_bashrc": None,
+    "conda_sh": None,
+    "conda_env_name": None,
+    "deepflame_bashrc": None,
+    "python_executable": None,
+    "default_np": 4,
+    "mpirun_command": "mpirun",
+}
+
+
+def get_config_dir() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg).expanduser().resolve() / APP_NAME
+    return Path.home().resolve() / ".config" / APP_NAME
+
+
+def get_config_path() -> Path:
+    return get_config_dir() / CONFIG_FILENAME
+
+
+def load_runtime_config() -> dict[str, Any]:
+    path = get_config_path()
+    config = dict(DEFAULT_CONFIG)
+    if path.is_file():
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+        config.update(loaded)
+    return config
+
+
+def save_runtime_config(config: dict[str, Any]) -> Path:
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def validate_config_key(key: str) -> str:
+    if key not in CONFIG_KEYS:
+        raise ValueError(
+            f"Unknown config key: {key}. Available keys: {', '.join(sorted(CONFIG_KEYS))}"
+        )
+    return key
+
+
+def coerce_config_value(key: str, value: str) -> Any:
+    if key == "default_np":
+        return int(value)
+    return value
+
+
+def set_config_value(key: str, value: str) -> tuple[dict[str, Any], Path]:
+    validate_config_key(key)
+    config = load_runtime_config()
+    config[key] = coerce_config_value(key, value)
+    return config, save_runtime_config(config)
+
+
+def unset_config_value(key: str) -> tuple[dict[str, Any], Path]:
+    validate_config_key(key)
+    config = load_runtime_config()
+    config[key] = DEFAULT_CONFIG[key]
+    return config, save_runtime_config(config)
+
+
+def describe_config_schema() -> dict[str, dict[str, Any]]:
+    return {
+        key: {
+            "description": CONFIG_KEYS[key],
+            "default": DEFAULT_CONFIG[key],
+        }
+        for key in sorted(CONFIG_KEYS)
+    }
+
+
+def resolve_runtime_config(overrides: dict[str, Any] | None = None) -> dict[str, Any]:
+    config = load_runtime_config()
+    for key, value in (overrides or {}).items():
+        if value is not None:
+            validate_config_key(key)
+            config[key] = value
+    return config

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,6 +61,16 @@ dfode-kit run-case --case /path/to/case --preview --json
 ### `sample`
 Sample thermochemical states from canonical flame simulation outputs and save them to HDF5.
 
+Example:
+
+```bash
+dfode-kit sample \
+  --mech /path/to/gri30.yaml \
+  --case /path/to/case \
+  --save /path/to/output.h5 \
+  --include_mesh
+```
+
 ### `augment`
 Apply perturbation-based dataset augmentation to sampled states.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,7 +8,9 @@ dfode-kit --help
 
 Available commands:
 
+- `config`
 - `init`
+- `run-case`
 - `sample`
 - `augment`
 - `label`
@@ -23,6 +25,15 @@ dfode-kit --list-commands
 
 ## Command overview
 
+### `config`
+Store and inspect machine-local runtime configuration such as OpenFOAM, Conda, and DeepFlame activation paths.
+
+Example:
+
+```bash
+dfode-kit config set openfoam_bashrc /opt/openfoam7/etc/bashrc
+```
+
 ### `init`
 Initialize canonical cases from explicit presets. The current supported case is `oneD-flame`, which preserves the current DFODE-kit empirical setup logic while making it previewable, overrideable, and serializable to JSON.
 
@@ -36,6 +47,15 @@ dfode-kit init oneD-flame \
   --phi 1.0 \
   --out /tmp/ch4_phi1_case \
   --preview --json
+```
+
+### `run-case`
+Run a case-local runner such as `Allrun` using the stored runtime configuration from `dfode-kit config`.
+
+Example:
+
+```bash
+dfode-kit run-case --case /path/to/case --preview --json
 ```
 
 ### `sample`

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ DFODE-kit is a Python toolkit for accelerating combustion chemistry integration 
 - **Getting Started**: environment setup and installation
 - **CLI**: current `dfode-kit` commands and their purpose
 - **Canonical Case Initialization**: preset-based case setup with preview/apply/config workflows
+- **Runtime Configuration and Case Execution**: persistent machine-local environment config plus reproducible case launching
 - **Architecture**: repo layout and current refactor direction
 - **Tutorials and Workflow**: how to think about the DFODE pipeline
 - **Agent Docs**: operational guidance for coding agents and maintainers

--- a/docs/init.md
+++ b/docs/init.md
@@ -78,6 +78,19 @@ The command is a **preset instantiator**, not a claim of universal best practice
 O2:1, N2:3.76
 ```
 
+## Environment note
+
+The `oneD-flame` init command computes flame properties through Cantera. In practice, run it from a Python environment that has Cantera available.
+
+In this environment, the validated choice was:
+
+```bash
+source /opt/openfoam7/etc/bashrc
+source /home/xk/miniconda3/etc/profile.d/conda.sh
+conda activate deepflame
+source /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+```
+
 ## Core workflow
 
 ### Preview a plan
@@ -115,6 +128,12 @@ dfode-kit init oneD-flame \
   --phi 1.0 \
   --out /tmp/ch4_phi1_case \
   --apply
+```
+
+If the output directory already exists, add:
+
+```bash
+--force
 ```
 
 ### Apply from a saved config

--- a/docs/run-case.md
+++ b/docs/run-case.md
@@ -1,0 +1,174 @@
+# Runtime Configuration and Case Execution
+
+DFODE-kit provides two CLI entrypoints for running DeepFlame/OpenFOAM cases reproducibly:
+
+- `dfode-kit config`
+- `dfode-kit run-case`
+
+This document is the shared reference for both humans and AI agents.
+
+## Why a persistent runtime config exists
+
+Running DeepFlame cases usually requires machine-local paths and environment activation steps that do not belong in case templates:
+
+1. source OpenFOAM
+2. source `conda.sh`
+3. activate a Conda environment
+4. source DeepFlame
+5. run the case
+
+Those machine-local settings are now stored through `dfode-kit config` instead of being retyped in every run command.
+
+## Config file location
+
+DFODE-kit stores runtime config in:
+
+- `${XDG_CONFIG_HOME}/dfode-kit/config.json` when `XDG_CONFIG_HOME` is set
+- otherwise `~/.config/dfode-kit/config.json`
+
+Show the resolved config path:
+
+```bash
+dfode-kit config path
+```
+
+## Supported config keys
+
+- `openfoam_bashrc`
+- `conda_sh`
+- `conda_env_name`
+- `deepflame_bashrc`
+- `python_executable`
+- `default_np`
+- `mpirun_command`
+
+Show schema with descriptions and defaults:
+
+```bash
+dfode-kit config schema
+```
+
+## Basic config workflow
+
+### Set values
+
+```bash
+dfode-kit config set openfoam_bashrc /opt/openfoam7/etc/bashrc
+dfode-kit config set conda_sh /home/xk/miniconda3/etc/profile.d/conda.sh
+dfode-kit config set conda_env_name deepflame
+dfode-kit config set deepflame_bashrc /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+```
+
+### Show current config
+
+```bash
+dfode-kit config show
+```
+
+### Show machine-readable config
+
+```bash
+dfode-kit config show --json
+```
+
+### Reset one key to its default
+
+```bash
+dfode-kit config unset python_executable
+```
+
+## Run a case
+
+The `run-case` command currently executes a case-local runner script, defaulting to `Allrun`.
+
+### Preview without executing
+
+```bash
+dfode-kit run-case \
+  --case /path/to/case \
+  --preview --json
+```
+
+### Execute using stored config
+
+```bash
+dfode-kit run-case \
+  --case /path/to/case \
+  --apply
+```
+
+### Execute with one-off overrides
+
+```bash
+dfode-kit run-case \
+  --case /path/to/case \
+  --apply \
+  --openfoam-bashrc /opt/openfoam7/etc/bashrc \
+  --conda-sh /home/xk/miniconda3/etc/profile.d/conda.sh \
+  --conda-env deepflame \
+  --deepflame-bashrc /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+```
+
+## Current execution contract
+
+`dfode-kit run-case` resolves a shell script equivalent to:
+
+```bash
+source <openfoam_bashrc>
+source <conda_sh>
+conda activate <conda_env_name>
+source <deepflame_bashrc>
+set -eo pipefail
+which dfLowMachFoam
+cd <case_dir>
+chmod +x <runner>
+./<runner>
+```
+
+## Required runtime config for `run-case`
+
+The following keys must be available either from stored config or per-command overrides:
+
+- `openfoam_bashrc`
+- `conda_sh`
+- `conda_env_name`
+- `deepflame_bashrc`
+
+## Output behavior
+
+### `--preview --json`
+Returns a JSON object containing:
+
+- `case_type`
+- `case_dir`
+- `runner`
+- `np`
+- `runtime_config`
+- `shell_lines`
+- `shell_script`
+
+### `--apply`
+Executes the resolved shell script.
+
+In normal mode, stdout/stderr stream to the terminal.
+
+In `--json` mode, stdout/stderr are written to:
+
+- `log.dfode-run-case.stdout`
+- `log.dfode-run-case.stderr`
+
+and the JSON result reports those paths.
+
+## Action rule
+
+At least one of the following must be specified:
+
+- `--preview`
+- `--apply`
+
+## Recommended workflow
+
+1. Set runtime config once with `dfode-kit config set ...`
+2. Preview the run plan with `dfode-kit run-case --preview --json`
+3. Execute with `dfode-kit run-case --apply`
+4. Use per-command overrides only when machine-local config differs from the default workstation setup

--- a/docs/run-case.md
+++ b/docs/run-case.md
@@ -59,6 +59,8 @@ dfode-kit config set conda_env_name deepflame
 dfode-kit config set deepflame_bashrc /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
 ```
 
+These are the exact values validated in this environment.
+
 ### Show current config
 
 ```bash
@@ -80,6 +82,16 @@ dfode-kit config unset python_executable
 ## Run a case
 
 The `run-case` command currently executes a case-local runner script, defaulting to `Allrun`.
+
+## Recommended environment split
+
+In this environment, the workflow that was validated successfully is:
+
+- use a DeepFlame-compatible Python environment for `dfode-kit init oneD-flame`
+  - example: `conda activate deepflame`
+- use persistent runtime config plus `dfode-kit run-case` for case execution
+- use a Python environment with `cantera`, `numpy`, and `h5py` available for `dfode-kit sample`
+  - in this environment, `conda activate deepflame` also works for sampling
 
 ### Preview without executing
 
@@ -169,6 +181,56 @@ At least one of the following must be specified:
 ## Recommended workflow
 
 1. Set runtime config once with `dfode-kit config set ...`
-2. Preview the run plan with `dfode-kit run-case --preview --json`
-3. Execute with `dfode-kit run-case --apply`
-4. Use per-command overrides only when machine-local config differs from the default workstation setup
+2. Create a case with `dfode-kit init oneD-flame ... --apply`
+3. Preview the run plan with `dfode-kit run-case --preview --json`
+4. Execute with `dfode-kit run-case --apply`
+5. Sample the finished case with `dfode-kit sample`
+6. Use per-command overrides only when machine-local config differs from the default workstation setup
+
+## Validated example: CH4 / air / phi=1 in this environment
+
+### 1. Store runtime config
+
+```bash
+dfode-kit config set openfoam_bashrc /opt/openfoam7/etc/bashrc
+dfode-kit config set conda_sh /home/xk/miniconda3/etc/profile.d/conda.sh
+dfode-kit config set conda_env_name deepflame
+dfode-kit config set deepflame_bashrc /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+```
+
+### 2. Initialize the case
+
+```bash
+source /opt/openfoam7/etc/bashrc
+source /home/xk/miniconda3/etc/profile.d/conda.sh
+conda activate deepflame
+source /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+
+python -m dfode_kit.cli_tools.main init oneD-flame \
+  --mech /home/xk/deepflame/df_1be82b6/deepflame-dev/mechanisms/CH4/gri30.yaml \
+  --fuel CH4:1 \
+  --oxidizer air \
+  --phi 1.0 \
+  --out /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --apply --force
+```
+
+### 3. Run the case
+
+```bash
+dfode-kit run-case \
+  --case /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --apply --json
+```
+
+### 4. Sample the finished case
+
+```bash
+source /home/xk/miniconda3/etc/profile.d/conda.sh
+conda activate deepflame
+python -m dfode_kit.cli_tools.main sample \
+  --mech /home/xk/deepflame/df_1be82b6/deepflame-dev/mechanisms/CH4/gri30.yaml \
+  --case /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --save /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli/ch4_phi1_sample.h5 \
+  --include_mesh
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
   - Getting Started: getting-started.md
   - CLI: cli.md
   - Canonical Case Initialization: init.md
+  - Runtime Configuration and Case Execution: run-case.md
   - Architecture: architecture.md
   - Tutorials and Workflow: tutorials.md
   - Shared Operational Docs:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -48,7 +48,9 @@ class DummyCommand:
 def test_load_command_specs_are_sorted():
     specs = command_loader.load_command_specs()
     assert list(specs) == sorted(specs)
+    assert 'config' in specs
     assert 'init' in specs
+    assert 'run-case' in specs
 
 
 def test_main_lists_commands_in_stable_order(monkeypatch, capsys):

--- a/tests/test_run_case_cli.py
+++ b/tests/test_run_case_cli.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from dfode_kit.cli_tools.commands import run_case_helpers
+
+
+class DummyArgs(SimpleNamespace):
+    pass
+
+
+def make_args(tmp_path, **overrides):
+    case_dir = tmp_path / 'case'
+    case_dir.mkdir()
+    (case_dir / 'Allrun').write_text('#!/bin/sh\nexit 0\n', encoding='utf-8')
+    data = {
+        'case': str(case_dir),
+        'runner': 'Allrun',
+        'np': None,
+        'preview': True,
+        'apply': False,
+        'json': True,
+        'openfoam_bashrc': '/opt/openfoam7/etc/bashrc',
+        'conda_sh': '/home/xk/miniconda3/etc/profile.d/conda.sh',
+        'conda_env': 'deepflame',
+        'deepflame_bashrc': '/home/xk/deepflame/bashrc',
+        'python_executable': None,
+        'mpirun_command': None,
+    }
+    data.update(overrides)
+    return DummyArgs(**data)
+
+
+def test_resolve_run_case_plan_uses_overrides(monkeypatch, tmp_path):
+    args = make_args(tmp_path)
+    monkeypatch.setattr(
+        run_case_helpers,
+        'resolve_runtime_config',
+        lambda overrides=None: {
+            'openfoam_bashrc': overrides['openfoam_bashrc'],
+            'conda_sh': overrides['conda_sh'],
+            'conda_env_name': overrides['conda_env_name'],
+            'deepflame_bashrc': overrides['deepflame_bashrc'],
+            'python_executable': overrides['python_executable'],
+            'default_np': 4,
+            'mpirun_command': 'mpirun',
+        },
+    )
+
+    plan = run_case_helpers.resolve_run_case_plan(args)
+
+    assert plan['case_type'] == 'deepflame-run-case'
+    assert plan['runner'] == 'Allrun'
+    assert 'conda activate deepflame' in plan['shell_script']
+    assert plan['runtime_config']['openfoam_bashrc'] == '/opt/openfoam7/etc/bashrc'
+
+
+def test_execute_run_case_json_mode_writes_logs(monkeypatch, tmp_path):
+    case_dir = tmp_path / 'case'
+    case_dir.mkdir()
+    plan = {
+        'case_dir': str(case_dir),
+        'runner': 'Allrun',
+        'shell_script': 'echo hello',
+    }
+
+    calls = {}
+
+    class Completed:
+        returncode = 0
+
+    def fake_run(command, stdout=None, stderr=None, text=None):
+        calls['command'] = command
+        if stdout is not None:
+            stdout.write('ok\n')
+        if stderr is not None:
+            stderr.write('')
+        return Completed()
+
+    monkeypatch.setattr(run_case_helpers.subprocess, 'run', fake_run)
+
+    result = run_case_helpers.execute_run_case(plan, quiet=True)
+
+    assert result['exit_code'] == 0
+    assert Path(result['stdout_log']).is_file()
+    assert Path(result['stderr_log']).is_file()
+    assert calls['command'] == ['bash', '-lc', 'echo hello']

--- a/tests/test_runtime_config.py
+++ b/tests/test_runtime_config.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+from dfode_kit import runtime_config
+
+
+def test_runtime_config_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv('XDG_CONFIG_HOME', str(tmp_path / 'xdg'))
+
+    path = runtime_config.get_config_path()
+    assert path == (tmp_path / 'xdg' / 'dfode-kit' / 'config.json')
+
+    config, saved_path = runtime_config.set_config_value('default_np', '8')
+    assert saved_path == path
+    assert config['default_np'] == 8
+
+    loaded = runtime_config.load_runtime_config()
+    assert loaded['default_np'] == 8
+
+    config, _ = runtime_config.unset_config_value('default_np')
+    assert config['default_np'] == runtime_config.DEFAULT_CONFIG['default_np']
+
+
+def test_validate_config_key_rejects_unknown():
+    try:
+        runtime_config.validate_config_key('nope')
+    except ValueError as exc:
+        assert 'Unknown config key' in str(exc)
+    else:
+        raise AssertionError('expected ValueError')


### PR DESCRIPTION
## Summary
- add persistent `dfode-kit config` support for OpenFOAM / Conda / DeepFlame runtime paths
- add `dfode-kit run-case` for previewing and executing case-local runners like `Allrun`
- document the validated 1D CH4 workflow including init, run-case, and sample

## Included
- runtime config storage under XDG config
- `config path/show/schema/set/unset`
- `run-case --preview/--apply/--json` with per-command runtime overrides
- shared docs for runtime configuration and case execution
- tests for runtime config and run-case planning/execution

## Verification
- `make verify`
- `make docs-build`
- real smoke tests of `run-case` on a dummy runner and a generated 1D flame case
- `dfode-kit sample` used successfully on the completed CH4 phi=1 case