### PR TITLE
Docs follow-up: README polish, paper references, and path-safety guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ This repository contains DFODE-kit, a Python toolkit for sampling combustion sta
 - Prefer explicit exceptions over bare asserts for runtime validation changes.
 - Keep stdout clean for result output; use logs/errors sparingly.
 - Do not mix unrelated refactors in the same branch.
+- Do not commit machine-specific local paths to published docs, README examples, or user-facing command snippets. Use portable placeholders like `/path/to/...`, `${VAR}`, or `<worktree-root>` instead.
 
 ## Read next
 - `docs/agents/README.md`

--- a/README.md
+++ b/README.md
@@ -1,24 +1,50 @@
-# DFODE-kit: Deep Learning Package for Combustion Kinetics
+# DFODE-kit
 
-DFODE-kit is an open-source Python package designed to accelerate combustion simulations by efficiently solving flame chemical kinetics governed by high-dimensional stiff ordinary differential equations (ODEs). This package integrates deep learning methodologies to replace conventional numerical integration, enabling significant speedups and improved accuracy.
+DFODE-kit is a Python toolkit for building machine-learning surrogates for combustion chemistry integration.
+It helps users move from **canonical flame simulations** to **sampled datasets**, **augmented and labeled training data**, and finally to **trained neural-network models** that can be deployed in DeepFlame/OpenFOAM workflows.
 
-## Features
-- **Efficient Sampling Module**: Extracts high-quality thermochemical states from low-dimensional manifolds in canonical flames.
-- **Data Augmentation**: Enhances training datasets to approximate high-dimensional composition spaces in turbulent flames.
-- **Neural Network Implementation**: Supports optimized training with physical constraints to ensure model fidelity.
-- **Seamless Integration**: Easily deploy trained models within the DeepFlame CFD solver or other platforms like OpenFOAM.
-- **Robust Performance**: Achieves high accuracy with up to two orders of magnitude speedup in various combustion scenarios.
+In practice, DFODE-kit sits between:
+- **DeepFlame / OpenFOAM**, which generate and run reacting-flow cases, and
+- **ML training workflows**, which need clean, structured, reproducible chemistry datasets.
 
-## Environment Setup
-Create a conda environment with Python 3.9:
+## Documentation
+
+- Project documentation: https://deepflame-ai.github.io/DFODE-kit/
+- DeepFlame documentation: https://deepflame.deepmodeling.com/en/latest/
+- DeepFlame source: https://github.com/deepmodeling/deepflame-dev
+
+## What DFODE-kit does
+
+DFODE-kit currently supports the core workflow below:
+
+1. **Configure runtime paths** for OpenFOAM, Conda, and DeepFlame
+2. **Initialize** canonical flame cases from explicit presets
+3. **Run** those cases reproducibly
+4. **Sample** thermochemical states into HDF5
+5. **Augment** sampled datasets
+6. **Label** them with Cantera/CVODE integration
+7. **Train** neural-network surrogates
+
+## Current CLI commands
+
+- `config` — store machine-local runtime paths
+- `init` — initialize canonical cases from explicit presets
+- `run-case` — execute a case-local runner such as `Allrun`
+- `sample` — convert case outputs to HDF5 datasets
+- `augment` — augment sampled states
+- `label` — generate supervised labels
+- `train` — train a neural-network model
+- `h52npy` — convert HDF5 scalar fields to NumPy arrays
+
+List commands locally with:
 
 ```bash
-conda create --name dfode_env python=3.9
-conda activate dfode_env
+dfode-kit --list-commands
 ```
 
 ## Installation
-To install DFODE-kit, clone the repository and install the dependencies:
+
+Clone the repository and install the package in editable mode:
 
 ```bash
 git clone https://github.com/deepflame-ai/DFODE-kit.git
@@ -26,70 +52,115 @@ cd DFODE-kit
 pip install -e .
 ```
 
-## Documentation
-Published docs:
-
-- https://deepflame-ai.github.io/DFODE-kit/
-
-## Usage
-Once you have installed DFODE-kit, you can use it to sample data, augment datasets, train models, and make predictions. Below is a basic command-line interface (CLI) format:
+If you want the lightweight local verification environment used in this repository:
 
 ```bash
-dfode-kit CMD ARGS
+uv venv .venv
+uv pip install --python .venv/bin/python -e '.[dev]'
 ```
 
+## Runtime requirements
 
-### Commands Available:
-- `config`: Store machine-local runtime paths such as OpenFOAM, Conda, and DeepFlame activation scripts.
-- `init`: Initialize canonical cases from explicit presets.
-- `run-case`: Execute a case-local runner such as `Allrun` using stored runtime configuration.
-- `sample`: Perform raw data sampling from canonical flame simulations.
-- `augment`: Apply random noise and physical constraints to improve the training dataset.
-- `label`: Generate supervised learning labels using Cantera's CVODE solver.
-- `train`: Train neural network models based on the specified datasets and parameters.
+DFODE-kit itself is a Python package, but some workflows also require local installations of:
 
-For example, a validated end-to-end 1D flame workflow is:
+- **OpenFOAM**
+- **DeepFlame**
+- **Conda** (or an equivalent Python environment manager)
+- **Cantera** for case initialization and labeling workflows
+
+For DeepFlame/OpenFOAM-backed case execution, you must configure machine-local runtime paths with `dfode-kit config`.
+
+## Quickstart: 1D CH4 flame workflow
+
+The example below shows a portable workflow for a 1D freely propagating premixed CH4/air flame at equivalence ratio 1.0.
+
+### 1. Store machine-local runtime configuration
 
 ```bash
-# one-time machine-local runtime config
-dfode-kit config set openfoam_bashrc /opt/openfoam7/etc/bashrc
-dfode-kit config set conda_sh /home/xk/miniconda3/etc/profile.d/conda.sh
+dfode-kit config set openfoam_bashrc /path/to/openfoam/etc/bashrc
+dfode-kit config set conda_sh /path/to/conda/etc/profile.d/conda.sh
 dfode-kit config set conda_env_name deepflame
-dfode-kit config set deepflame_bashrc /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+dfode-kit config set deepflame_bashrc /path/to/deepflame-dev/bashrc
+```
 
-# init case from a DeepFlame-compatible Python env
-source /opt/openfoam7/etc/bashrc
-source /home/xk/miniconda3/etc/profile.d/conda.sh
+### 2. Initialize a canonical 1D flame case
+
+Run this from a Python environment that has Cantera available:
+
+```bash
+source /path/to/openfoam/etc/bashrc
+source /path/to/conda/etc/profile.d/conda.sh
 conda activate deepflame
-source /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+source /path/to/deepflame-dev/bashrc
+
 python -m dfode_kit.cli_tools.main init oneD-flame \
-  --mech /home/xk/deepflame/df_1be82b6/deepflame-dev/mechanisms/CH4/gri30.yaml \
+  --mech /path/to/mechanisms/CH4/gri30.yaml \
   --fuel CH4:1 \
   --oxidizer air \
   --phi 1.0 \
-  --out /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --out /path/to/run/oneD_flame_CH4_phi1 \
   --apply --force
+```
 
-# run case
+### 3. Run the case
+
+```bash
 python -m dfode_kit.cli_tools.main run-case \
-  --case /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --case /path/to/run/oneD_flame_CH4_phi1 \
   --apply --json
+```
 
-# sample case
+### 4. Sample the finished case into HDF5
+
+```bash
 python -m dfode_kit.cli_tools.main sample \
-  --mech /home/xk/deepflame/df_1be82b6/deepflame-dev/mechanisms/CH4/gri30.yaml \
-  --case /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
-  --save /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli/ch4_phi1_sample.h5 \
+  --mech /path/to/mechanisms/CH4/gri30.yaml \
+  --case /path/to/run/oneD_flame_CH4_phi1 \
+  --save /path/to/run/oneD_flame_CH4_phi1/ch4_phi1_sample.h5 \
   --include_mesh
 ```
 
-Comprehensive tutorials are provided in the `tutorials/` directory, including step-by-step guides for 1D premixed flames and 2D HIT flames.
+## Recommended documentation entry points
 
-Note that running the simulations requires DeepFlame to be installed. Refer to the [DeepFlame GitHub repository](https://github.com/deepmodeling/deepflame-dev) and [documentation](https://deepflame.deepmodeling.com/en/latest/) for installation instructions.
+If you are using the CLI, start with:
+- https://deepflame-ai.github.io/DFODE-kit/cli/
+- https://deepflame-ai.github.io/DFODE-kit/init/
+- https://deepflame-ai.github.io/DFODE-kit/run-case/
 
-## Directories
-- **dfode-kit**: Main procedure and functions.
-- **mechanisms**: Thermochemical mechanism folder.
-- **canonical_cases**: Canonical cases for data sampling.
-- **tutorials**: Tutorials with sampling cases. 
+If you are working on the repository itself, see:
+- `AGENTS.md`
+- `docs/agents/README.md`
 
+## Repository layout
+
+- `dfode_kit/cli_tools/` — CLI entrypoints and subcommands
+- `dfode_kit/df_interface/` — DeepFlame/OpenFOAM-facing helpers and case setup
+- `dfode_kit/data_operations/` — dataset I/O, sampling, augmentation, labeling
+- `dfode_kit/dfode_core/` — model and training code
+- `canonical_cases/` — canonical flame case templates
+- `tutorials/` — tutorial notebooks and workflow examples
+- `docs/` — published project documentation
+- `tests/` — lightweight verification tests
+
+## Design principles in the current refactor
+
+Recent work in this repository focuses on making DFODE-kit:
+
+- easier to use from the CLI,
+- easier for coding agents to operate safely,
+- more reproducible for scientific workflows,
+- more explicit about empirical setup assumptions,
+- more modular for experimentation with model and training changes.
+
+## Verification for contributors
+
+This repository includes a lightweight local verification loop:
+
+```bash
+make bootstrap-harness
+make verify
+```
+
+## License
+
+This project is distributed under the terms in [`LICENSE`](LICENSE).

--- a/README.md
+++ b/README.md
@@ -187,6 +187,49 @@ The following papers provide scientific context for DFODE-kit and closely relate
 }
 ```
 
+### GPU/ANN-accelerated LES of swirling premixed flames
+
+```bibtex
+@article{zhang2024graphics,
+  title={Graphics processing unit/artificial neural network-accelerated large-eddy simulation of swirling premixed flames},
+  author={Zhang, Min and Mao, Runze and Li, Han and An, Zhenhua and Chen, Zhi X},
+  journal={Physics of Fluids},
+  volume={36},
+  number={5},
+  year={2024},
+  publisher={AIP Publishing}
+}
+```
+
+### Integrated GPU + machine learning acceleration framework
+
+```bibtex
+@article{mao2024integrated,
+  title={An integrated framework for accelerating reactive flow simulation using GPU and machine learning models},
+  author={Mao, Runze and Zhang, Min and Wang, Yingrui and Li, Han and Xu, Jiayang and Dong, Xinyu and Zhang, Yan and Chen, Zhi X},
+  journal={Proceedings of the Combustion Institute},
+  volume={40},
+  number={1-4},
+  pages={105512},
+  year={2024},
+  publisher={Elsevier}
+}
+```
+
+### DeepFlame platform paper
+
+```bibtex
+@article{mao2023deepflame,
+  title={DeepFlame: A deep learning empowered open-source platform for reacting flow simulations},
+  author={Mao, Runze and Lin, Minqi and Zhang, Yan and Zhang, Tianhan and Xu, Zhi-Qin John and Chen, Zhi X},
+  journal={Computer Physics Communications},
+  volume={291},
+  pages={108842},
+  year={2023},
+  publisher={Elsevier}
+}
+```
+
 ## Design principles in the current refactor
 
 Recent work in this repository focuses on making DFODE-kit:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,51 @@ If you are working on the repository itself, see:
 - `docs/` — published project documentation
 - `tests/` — lightweight verification tests
 
+## Related papers
+
+The following papers provide scientific context for DFODE-kit and closely related workflows:
+
+### DFODE-kit package paper
+
+```bibtex
+@article{li2025dfode,
+  title={DFODE-kit: Deep learning package for solving Flame chemical kinetics with high-dimensional stiff Ordinary Differential Equations},
+  author={Li, Han and Xiao, Ke and Xu, Yangchen and Zhang, Haoze and Chen, Zhenyi and Mao, Runze and Chen, Zhi X},
+  journal={Computer Physics Communications},
+  pages={110013},
+  year={2025},
+  publisher={Elsevier}
+}
+```
+
+### Multi-fuel generalization and a posteriori validation
+
+```bibtex
+@article{li2025comprehensive,
+  title={Comprehensive deep learning for combustion chemistry integration: Multi-fuel generalization and a posteriori validation in reacting flow},
+  author={Li, Han and Yang, Ruixin and Xu, Yangchen and Zhang, Min and Mao, Runze and Chen, Zhi X},
+  journal={Physics of Fluids},
+  volume={37},
+  number={1},
+  year={2025},
+  publisher={AIP Publishing}
+}
+```
+
+### Physics-aware data augmentation and scale separation
+
+```bibtex
+@article{xiao2026enhancing,
+  title={Enhancing deep learning of ammonia/natural gas combustion kinetics via physics-aware data augmentation and scale separation},
+  author={Xiao, Ke and Xu, Yangchen and Li, Han and Chen, Zhi X},
+  journal={Fuel},
+  volume={419},
+  pages={138904},
+  year={2026},
+  publisher={Elsevier}
+}
+```
+
 ## Design principles in the current refactor
 
 Recent work in this repository focuses on making DFODE-kit:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ cd DFODE-kit
 pip install -e .
 ```
 
+## Documentation
+Published docs:
+
+- https://deepflame-ai.github.io/DFODE-kit/
+
 ## Usage
 Once you have installed DFODE-kit, you can use it to sample data, augment datasets, train models, and make predictions. Below is a basic command-line interface (CLI) format:
 

--- a/docs/agents/worktrees.md
+++ b/docs/agents/worktrees.md
@@ -4,10 +4,10 @@ Use separate git worktrees for parallel agent tasks.
 
 ## Current branches/worktrees
 - integration branch: `agent-harness-refactor`
-- `/mnt/d/u_deepflame_agent/Projects/dfode-wt/cli` -> `agent-cli-contract`
-- `/mnt/d/u_deepflame_agent/Projects/dfode-wt/train` -> `agent-train-config`
-- `/mnt/d/u_deepflame_agent/Projects/dfode-wt/data` -> `agent-data-io`
-- `/mnt/d/u_deepflame_agent/Projects/dfode-wt/ci` -> `agent-ci-tests`
+- `<worktree-root>/cli` -> `agent-cli-contract`
+- `<worktree-root>/train` -> `agent-train-config`
+- `<worktree-root>/data` -> `agent-data-io`
+- `<worktree-root>/ci` -> `agent-ci-tests`
 
 ## Guidelines
 - One worktree = one main concern.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -31,7 +31,7 @@ Store and inspect machine-local runtime configuration such as OpenFOAM, Conda, a
 Example:
 
 ```bash
-dfode-kit config set openfoam_bashrc /opt/openfoam7/etc/bashrc
+dfode-kit config set openfoam_bashrc /path/to/openfoam/etc/bashrc
 ```
 
 ### `init`

--- a/docs/init.md
+++ b/docs/init.md
@@ -82,13 +82,13 @@ O2:1, N2:3.76
 
 The `oneD-flame` init command computes flame properties through Cantera. In practice, run it from a Python environment that has Cantera available.
 
-In this environment, the validated choice was:
+A typical setup is:
 
 ```bash
-source /opt/openfoam7/etc/bashrc
-source /home/xk/miniconda3/etc/profile.d/conda.sh
+source /path/to/openfoam/etc/bashrc
+source /path/to/conda/etc/profile.d/conda.sh
 conda activate deepflame
-source /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+source /path/to/deepflame-dev/bashrc
 ```
 
 ## Core workflow

--- a/docs/run-case.md
+++ b/docs/run-case.md
@@ -53,13 +53,13 @@ dfode-kit config schema
 ### Set values
 
 ```bash
-dfode-kit config set openfoam_bashrc /opt/openfoam7/etc/bashrc
-dfode-kit config set conda_sh /home/xk/miniconda3/etc/profile.d/conda.sh
+dfode-kit config set openfoam_bashrc /path/to/openfoam/etc/bashrc
+dfode-kit config set conda_sh /path/to/conda/etc/profile.d/conda.sh
 dfode-kit config set conda_env_name deepflame
-dfode-kit config set deepflame_bashrc /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+dfode-kit config set deepflame_bashrc /path/to/deepflame-dev/bashrc
 ```
 
-These are the exact values validated in this environment.
+Use paths appropriate for your local installation.
 
 ### Show current config
 
@@ -115,10 +115,10 @@ dfode-kit run-case \
 dfode-kit run-case \
   --case /path/to/case \
   --apply \
-  --openfoam-bashrc /opt/openfoam7/etc/bashrc \
-  --conda-sh /home/xk/miniconda3/etc/profile.d/conda.sh \
+  --openfoam-bashrc /path/to/openfoam/etc/bashrc \
+  --conda-sh /path/to/conda/etc/profile.d/conda.sh \
   --conda-env deepflame \
-  --deepflame-bashrc /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+  --deepflame-bashrc /path/to/deepflame-dev/bashrc
 ```
 
 ## Current execution contract
@@ -187,31 +187,31 @@ At least one of the following must be specified:
 5. Sample the finished case with `dfode-kit sample`
 6. Use per-command overrides only when machine-local config differs from the default workstation setup
 
-## Validated example: CH4 / air / phi=1 in this environment
+## Example: CH4 / air / phi=1 workflow
 
 ### 1. Store runtime config
 
 ```bash
-dfode-kit config set openfoam_bashrc /opt/openfoam7/etc/bashrc
-dfode-kit config set conda_sh /home/xk/miniconda3/etc/profile.d/conda.sh
+dfode-kit config set openfoam_bashrc /path/to/openfoam/etc/bashrc
+dfode-kit config set conda_sh /path/to/conda/etc/profile.d/conda.sh
 dfode-kit config set conda_env_name deepflame
-dfode-kit config set deepflame_bashrc /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+dfode-kit config set deepflame_bashrc /path/to/deepflame-dev/bashrc
 ```
 
 ### 2. Initialize the case
 
 ```bash
-source /opt/openfoam7/etc/bashrc
-source /home/xk/miniconda3/etc/profile.d/conda.sh
+source /path/to/openfoam/etc/bashrc
+source /path/to/conda/etc/profile.d/conda.sh
 conda activate deepflame
-source /home/xk/deepflame/df_1be82b6/deepflame-dev/bashrc
+source /path/to/deepflame-dev/bashrc
 
 python -m dfode_kit.cli_tools.main init oneD-flame \
-  --mech /home/xk/deepflame/df_1be82b6/deepflame-dev/mechanisms/CH4/gri30.yaml \
+  --mech /path/to/mechanisms/CH4/gri30.yaml \
   --fuel CH4:1 \
   --oxidizer air \
   --phi 1.0 \
-  --out /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --out /path/to/run/oneD_flame_CH4_phi1 \
   --apply --force
 ```
 
@@ -219,18 +219,18 @@ python -m dfode_kit.cli_tools.main init oneD-flame \
 
 ```bash
 dfode-kit run-case \
-  --case /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
+  --case /path/to/run/oneD_flame_CH4_phi1 \
   --apply --json
 ```
 
 ### 4. Sample the finished case
 
 ```bash
-source /home/xk/miniconda3/etc/profile.d/conda.sh
+source /path/to/conda/etc/profile.d/conda.sh
 conda activate deepflame
 python -m dfode_kit.cli_tools.main sample \
-  --mech /home/xk/deepflame/df_1be82b6/deepflame-dev/mechanisms/CH4/gri30.yaml \
-  --case /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli \
-  --save /home/xk/deepflame_runs/oneD_flame_CH4_phi1_cli/ch4_phi1_sample.h5 \
+  --mech /path/to/mechanisms/CH4/gri30.yaml \
+  --case /path/to/run/oneD_flame_CH4_phi1 \
+  --save /path/to/run/oneD_flame_CH4_phi1/ch4_phi1_sample.h5 \
   --include_mesh
 ```


### PR DESCRIPTION
## Summary
- remove machine-specific local paths from published docs and README examples
- add a no-local-paths rule to `AGENTS.md`
- expand the README with published docs link and related papers
- keep the 1D workflow examples portable for GitHub-hosted documentation

## Includes
- README cleanup and restructuring
- related papers section in `README.md`
- portable placeholder paths in user-facing docs
- agent guidance to avoid committing workstation-specific paths

## Verification
- `make docs-build`
