### PR TITLE
Defer Cantera imports in data modules for harness CI

### DIFF
--- a/dfode_kit/data/augment.py
+++ b/dfode_kit/data/augment.py
@@ -1,10 +1,11 @@
 import time
 
-import cantera as ct
 import numpy as np
 
 
 def single_step(npstate, chem, time_step=1e-6):
+    import cantera as ct
+
     gas = ct.Solution(chem)
     T_old, P_old, Y_old = npstate[0], npstate[1], npstate[2:]
     gas.TPY = T_old, P_old, Y_old
@@ -33,6 +34,8 @@ def random_perturb(
     inert_idx: int = -1,
     time_step: float = 1e-6,
 ) -> np.ndarray:
+    import cantera as ct
+
     array = array[array[:, 0] > frozenTem]
 
     gas = ct.Solution(mech_path)
@@ -141,6 +144,8 @@ def label(
     mech_path: str,
     time_step: float = 1e-06,
 ) -> np.ndarray:
+    import cantera as ct
+
     from dfode_kit.data.integration import advance_reactor
 
     gas = ct.Solution(mech_path)

--- a/dfode_kit/data/integration.py
+++ b/dfode_kit/data/integration.py
@@ -1,6 +1,5 @@
 import h5py
 import numpy as np
-import cantera as ct
 
 from dfode_kit.data.contracts import MECHANISM_ATTR, require_h5_attr, read_scalar_field_datasets
 from dfode_kit.data.io_hdf5 import get_TPY_from_h5, touch_h5
@@ -43,6 +42,7 @@ def load_model(model_path, device, model_class, model_layers):
 
 def predict_Y(model, model_path, d_arr, mech, device):
     import torch
+    import cantera as ct
 
     gas = ct.Solution(mech)
     n_species = gas.n_species
@@ -81,6 +81,8 @@ def predict_Y(model, model_path, d_arr, mech, device):
 
 
 def nn_integrate(orig_arr, model_path, device, model_class, model_layers, time_step, mech, frozen_temperature=510):
+    import cantera as ct
+
     model = load_model(model_path, device, model_class, model_layers)
 
     mask = orig_arr[:, 0] > frozen_temperature
@@ -123,6 +125,8 @@ def integrate_h5(
     nn_integration=False,
     model_settings=None,
 ):
+    import cantera as ct
+
     """Process scalar-field datasets and save CVODE / NN integration outputs."""
     with h5py.File(file_path, 'r') as f:
         mech = require_h5_attr(f, MECHANISM_ATTR)
@@ -183,6 +187,8 @@ def calculate_error(
     save_path2,
     error='RMSE'
 ):
+    import cantera as ct
+
     gas = ct.Solution(mech_path)
 
     with h5py.File(save_path1, 'r') as f1, h5py.File(save_path2, 'r') as f2:

--- a/dfode_kit/data/label.py
+++ b/dfode_kit/data/label.py
@@ -1,6 +1,5 @@
 import time
 
-import cantera as ct
 import numpy as np
 
 
@@ -9,6 +8,8 @@ def label_npy(
     time_step,
     source_path,
 ):
+    import cantera as ct
+
     from dfode_kit.data.integration import advance_reactor
 
     gas = ct.Solution(mech_path)


### PR DESCRIPTION
## Summary
- defer `cantera` imports in `dfode_kit.data.integration`
- defer `cantera` imports in `dfode_kit.data.augment`
- defer `cantera` imports in `dfode_kit.data.label`
- keep lightweight harness imports working in environments without Cantera installed

## Why
PR #15 introduced tests that import canonical `dfode_kit.data` modules directly. GitHub Actions runs the lightweight harness without Cantera installed, so module-level Cantera imports caused the harness workflow to fail after merge.

## Verification
- `make verify`
- `make docs-build`
